### PR TITLE
Revamp XDA template

### DIFF
--- a/blissroms_thread_template
+++ b/blissroms_thread_template
@@ -1,134 +1,76 @@
-[CENTER][IMG]https://i.imgur.com/qtDlAth.png[/IMG]
-[font=Arial][b][color=deepskyblue][size=5]Team Bliss [/size][/color][/b][color=deepskyblue][size=5]is pleased to present to you[/size][/font]
-[font=Arial][b][size=7]BlissRoms based on Android 10[/size][/b][/font][/color]
+[center][img]https://i.imgur.com/qtDlAth.png[/img][/center]
+[center]
+[b]BlissRoms is designed to bring the open source community a quality OS that can run on all of your devices as a daily driver.[/b][b] We deliver a wide selection of customization options from around the Android community, as well as unique features developed by our team.[/b][/center]
+[center]
+[img]https://i.imgur.com/A7JONTD.png[/img][/center]
+[center][url=https://github.com/BlissRoms][b][u]BlissRoms Sources[/u][/b][/url][/center]
+[center][url=https://github.com/BlissRoms-Devices][u][b]BlissRoms Device Sources[/b][/u][/url][/center]
+[center]
 
-[B]Our focus is to bring the Open Source community a quality OS that can run on all your devices as a daily driver, syncing your apps + settings + customizations across all platforms you run Bliss on.[/B]
-[B]Bliss ROMs comes with a wide selection of customization options from around the Android community as well as unique options developed by our team. With so many options available, you’ll find it hard not to enjoy the Blissful experience.[/B]
+[img]https://i.imgur.com/M8leihh.png[/img]
+Official maintainers - add direct links to SourceForge here.[/center]
+[center]Example: [url=https://sourceforge.net/projects/blissroms/files/Q/bullhead/][u][b]Nexus 5X (bullhead)[/b][/u][/url][/center]
+[center]
+[size=4][color=DeepSkyBlue][img]https://i.imgur.com/YlIC2kZ.png[/img]
+[/color][/size]Team Bliss recommends using [url=https://opengapps.org]OpenGApps[/url].[/center]
+[center](Note to maintainers - if your device has inbuilt GApps, replace above with following)[/center]
+[center]GApps is bundled with the ROM package! Please do not flash another GApps distribution.[/center]
+[center](Note to maintainers - if your device has better compatibility with another GApps distribution, replace above with following)[/center]
+[center]This device is best compatible with <insert GApps name here>.[/center]
+[center](Note to maintainers - if your system partition is too full for any GApps installation, DELETE this entire section)[/center]
+[center][img]https://i.imgur.com/Cz6L1rZ.png[/img]
 
-[IMG]https://i.imgur.com/A7JONTD.png[/IMG]
-[CODE]
-[CENTER][B][COLOR=DeepSkyBlue][SIZE=4][U][URL="https://github.com/BlissRoms"]BlissRoms Sources[/URL][/U][/SIZE][/COLOR][/B]
+[size=5][color=red]Team Bliss is not responsible in any way for anything that happens to your device.[/color][/size][/center]
+[center][color=red][size=5]All of our software are provided as-is, with no warranties supplied in any form.[/size][/color][/center]
+[center]Please familiarize yourself with flashing and custom ROM usage before attempting to flash BlissRoms.[/center]
+[center]Please make sure you download the correct version of Bliss for your device.[/center]
+[center]Flashing an incorrect build may brick your device. Again, we bear no responsibility for your actions.[/center]
+[center][ul]
+[li]Make sure you have a custom recovery, such as TWRP, installed[/li]
+[li]Download the latest BlissRoms package for your device[/li]
+[li]Download the recommended GApps package if you plan to use GApps
+(Note to maintainers - DELETE this bullet point if this is not applicable)[/li]
+[li]Reboot into the custom recovery[/li]
+[li]Back up your current partitions in case you need to recover your device.[/li]
+[li]Perform a full factory reset.[/li]
+[li]Flash the BlissRoms package.[/li]
+[li]Flash the recommended GApps package if you plan to use GApps
+(Note to maintainers - DELETE this bullet point if this is not applicable)[/li]
+[li]Reboot[/li]
+[/ul]
 
-[B][COLOR=DeepSkyBlue][SIZE=4][U][URL="https://github.com/BlissRoms-Devices"]BlissRoms Device Sources[/URL][/U][/SIZE][/COLOR][/B][/CENTER]
-[/CODE]
+The first boot may take a long time, due to GApps optimization.
 
-[IMG]https://i.imgur.com/M8leihh.png[/IMG]
+[/center]
+[center][img]https://i.imgur.com/aWICthQ.png[/img][/center]
+[center]What is currently not working:[/center]
+[center][ul]
+[li]Example: Bluetooth[/li]
+[li]NFC[/li]
+[/ul]
 
-[SIZE="5"][COLOR=DeepSkyBlue][B]Bliss Device Downloads
-[URL="https://downloads.blissroms.com/BlissRoms/Q/"]Bliss Download Server[/URL]
-[URL="https://sourceforge.net/projects/blissroms/files/Q//"]SourceForge[/URL]
-[/SIZE][/COLOR][/B]
+(Note to maintainers - if your device does not have any known bugs, please delete the above, but RETAIN the bug reporting information below)
+(Note to maintainers - if a bug is fixed, remove it from the OP and post an update to the thread so that users know when it has been fixed)[/center]
+[center][size=5][color=red]Please read the following very carefully before reporting bugs![/color][/size]
 
-[SIZE="4"][COLOR="DeepSkyBlue"][IMG]https://i.imgur.com/YlIC2kZ.png[/IMG]
-[B][URL="https://sourceforge.net/projects/opengapps/files/arm64/"]OpenGapps Project[/URL][/B]
-[/COLOR][/SIZE]
-[IMG]https://i.imgur.com/Cz6L1rZ.png[/IMG]
+If you have not performed a clean flash (as in, you have not factory reset your device), please do NOT report bugs.
+If you have installed any modifications to the system partition, please do NOT report bugs.
+If somebody else has reported the bug, please do NOT report the same bug.[/center]
+[center]We are currently preparing an updated bug reporting system for all users. Please refer back to this section.[/center]
+[center]We will update this section once the bug reporting system is ready.[/center]
+[center]
+[img]https://i.imgur.com/myCEQmI.png[/img]
 
-[SIZE=5][COLOR=red]Team Bliss is not responsible in any way for anything that happens to your device in the process of installing[/COLOR][/SIZE]
-[CODE][B]Please familiarize yourself with flashing and custom rom use before attempting to flash the rom.  Please make sure you download the correct version of Bliss for your specific device.  The links are labeled clearly.[/B]
-[LIST]
-[*][B]Make sure you are rooted[/B]
-[*][B]Make sure you have a custom recovery installed(TWRP is the preferred recovery)[/B]
-[*][B]Download the latest Bliss Rom & the latest GApps package[/B]
-[*][B]Boot into recovery[/B]
-[*][B]Backup your current ROM[/B]
-[*][B]Perform a FULL factory wipe and wipe/system and dalvik cache as a precaution[/B]
-[*][B]Flash Bliss Rom[/B]
-[*][B]Reboot recovery[/B]
-[*][B] Flash OpenGapps--NANO PACKAGE!![/B]
-[*][B] *Flash magisk* optional[/B]
-[*][B]First boot may take up to 10 minutes. This is due to Gapps and root optimization.[/B]
-[/LIST][/CENTER][/CODE]
+All of our team members and official maintainers can be found on our [url=https://blissroms.com][u][b]official website.[/b][/u][/url][/center]
+[center](Note to maintainers - if you have received your device or kernel tree from another developer/maintainer, here would be a good place to mention them)[/center]
 
-[CENTER][IMG]https://i.imgur.com/aWICthQ.png[/IMG]
+[center][img]https://i.imgur.com/wwdX3pH.png[/img]
+[url=https://blissroms.com][u][b]Official Website[/b][/u][/url][/center]
+[center]Keep in touch with us by following us on the following platforms![/center]
+[center][url=https://www.facebook.com/BlissFamilyOfROMs][u][b]Facebook[/b][/u][/url][/center]
+[center][url=https://twitter.com/Bliss_ROMs][u][b]Twitter[/b][/u][/url][/center]
+[center][url=https://www.instagram.com/blissroms][u][b]Instagram[/b][/u][/url][/center]
+[center][url=https://t.me/Team_Bliss_Community][u][b]Telegram[/b][/u][/url][/center]
 
-[CODE]
-[B]If you have a major bug to report that has not been reported already, please take the following steps to report it to us.  It will save you and our team quite some time.[/B]
-[LIST]
-[*][B]Download the [URL="https://play.google.com/store/apps/details?id=com.nolanlawson.logcat&hl=en"][COLOR=DeepSkyBlue][U]Catlog[/U][/COLOR][/URL] app from the Play Store.[/B]
-[*][B]There is also a donate version which you can purchase to show appreciation.[/B]
-[*][B]After downloading the Catlog app, go to the app settings, and change the log level to Debug.[/B]
-[*][B]Clear all previous logs and take the exact steps to produce the error you are receiving.[/B]
-[*][B]As soon as you receive the error (probably a force close), go straight into Catlog and stop the log recording.[/B]
-[*][B]Copy and paste the entire log either to [URL="http://hastebin.com"][COLOR=DeepSkyBlue][U]Hastebin[/U][/COLOR][/URL] or [URL="http://pastebin.com"][COLOR=DeepSkyBlue][U]Pastebin[/U][/COLOR][/URL][/B]
-[*][B]Save the log, and copy and paste the link into the forum with a brief description of the error.[/B]
-[/LIST][/CODE]
-
-[IMG]https://i.imgur.com/myCEQmI.png[/IMG]
-[CODE][COLOR=DeepSkyBlue][B]
-@Jackeagle 
-@electrikjesus
-@Rohan purohit
-@rwaterspf1 
-@Makaveli_da_dev 
-@ElfinJNoty 
-@BitOBSessiOn 
-@customworx
-@nilac 
-@sixohtew 
-@aclegg2011 
-@Roger.T 
-@T.M.Wrath 
-@kanttii 
-@rev3nt3ch 
-@techfreak243 
-@SuperDroidBond 
-@USA_RedDragon 
-@bcrichster
-@deadmanxXD 
-@krittin98 
-@BlackScorpion 
-@techexhibeo 
-@droidbot 
-@siphonay 
-@pacer456 
-@nitin1438 
-@theGeekyLad 
-@kunalshah912
-@lordarcadius
-@AryanAA
-[/B]
-[/COLOR][/CODE]
-[B]A huge thanks to Chainfire, CM/LineageOS, Android-x86, Jide, @[URL="https://forum.xda-developers.com/member.php?u=4289533"]farmerbb[/URL] & all the other developers who work hard to keep all the great features coming![/B]
-[B]We really appreciate all your knowledge & hard work![/B][/CENTER]
-
-[color=#44b8ff][size=5][b]About BlissROMs[/b][/size][/color]
-
-[b]Team membership consist of and provides:[/b]
-Training, development opportunities, design opportunities, build servers when available, download servers, design & development software, as well as a stress free team oriented community of professionals and mentors in all fields revolving around Android development. To join our team, please visit either of our websites, and find the Join Team Bliss link. [font=Arial]
-
-[b][color=#000000]If someone wants to donate, please do so via this PayPal link:[/color][/b]
-[b][img]https://imgur.com/yMdcL5e.png[/img][/b]
-
-[b][url=https://www.paypal.me/TeamBliss][color=DeepSkyBlue][u]PayPal Link[/u][/color][/url][/b]
-
-[b]WE ARE A U.S. FEDERAL NON-PROFIT ORGANIZATION (501c3)[/b]
-
-[b][img]https://imgur.com/2rw5ves.png[/img][/b]
-
-[b]We receive a small donation each time you make a purchase with “Amazon Smile”:[/b]
-
-[url=https://smile.amazon.com/ch/82-3580195][/url][b][color=#000000][url=https://smile.amazon.com/ch/82-3580195]https://smile.amazon.com/ch/82-3580195[/url][/color][/b]
-
-[B][CENTER]
-[SIZE="6"][COLOR="Red"]Notice[/COLOR][/SIZE]
-
-The OP and most recent discussions will generally help to answer any questions you will encounter. If not, we will do our best to answer your questions & concerns as soon as possible.
-We will also simply direct you to the OP if the answer is contained there. We encourage community minded interactions: users helping fellow users allows Team Bliss to focus on the work involved to make things Blissful.
-Please do not ask for ETA's
-We will not tolerate any rudeness or anyone being disrespectful in this thread. Moderators, feel free to enforce anything you feel is necessary to stop bad posts
-
-Team Bliss will allow some minor off-topic comments in our development threads. Please post in the general forums for off-topic comments and/or questions. Overall, please keep comments relevant to development, as this better helps you and our teamwhen trying to determine problems that users are having. We appreciate all levels of knowledge in our threads, and therefore we ask that the seasoned members be helpful to those with less knowledge. Most importantly, do NOT troll those with less knowledge than yourself.
-Should you feel inclined to not abide by our request, the XDA Moderators may be called in to remove posts. We thank you for adhering to our thread rules.[/CENTER][/B]
-
-[CENTER][IMG]https://i.imgur.com/wwdX3pH.png[/IMG]
-
-[CENTER][CODE][COLOR=DeepSkyBlue][B][U][SIZE=5][URL="https://blissroms.com"]Website[/URL][/SIZE][/U][/B][/COLOR]
-
-[COLOR=DeepSkyBlue][B][U][SIZE=5]Official Platform Links[/SIZE][/U][/B][/COLOR]
-[URL="https://www.facebook.com/BlissFamilyOfROMs"]BlissRoms Facebook[/URL]
-[URL="https://twitter.com/Bliss_ROMs"]BlissRoms Twitter[/URL]
-[URL="https://www.instagram.com/blissroms"]BlissRoms Instagram[/URL]
-[URL="https://t.me/Team_Bliss_Community"]BlissRoms Telegram[/URL][/CODE][/CENTER]
-
-[SIZE=4][B][COLOR=DeepSkyBlue]Thank you for using Bliss!  And as always: #StayBlissful[/COLOR][/B][/SIZE][/CENTER]
+[center]
+[size=4][b][color=DeepSkyBlue]Thank you for using Bliss!  And as always, #StayBlissful![/color][/b][/size][/center]


### PR DESCRIPTION
What has been changed
 - Reduced credits section. Credits are shown on our official website anyway
 - Removed nonprofit links and donation links. Shown on official website
 - Cleared up wording and unified branding
 - Installation process has been simplified (no root required)
 - GApps section has been clarified
 - Notes to maintainers (both official and unofficial) added

What still needs to be fixed
 - Social media links need icons
 - May need new header image designs